### PR TITLE
Fix Bikeshed errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2243,7 +2243,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
             1. Else:
 
                 1. Execute the [=issuing a credential request to an authenticator=] algorithm with |authenticator|,
-                   |savedCredentialIds| and |options|.{{CredentialRequestOptions/publicKey}}.
+                    |savedCredentialIds| and |options|.{{CredentialRequestOptions/publicKey}}.
 
                     Note: This branch is taken if <code>|options|.{{CredentialRequestOptions/mediation}}</code> is {{CredentialMediationRequirement/conditional}}
                     and the |authenticator| does not support the [=silentCredentialDiscovery=] operation to allow use of such authenticators during a
@@ -2376,7 +2376,7 @@ This algorithm accepts the following arguments:
     ::  The [=hash of the serialized client data=] represented by |clientDataJSON|.
 
     :   <dfn>authenticatorExtensions</dfn>
-    ::  A [=map=] containing [=extension IDs=] to the [=base64url encoding=] of the [=client extension processing=]
+    ::  A [=map=] containing [=extension identifiers=] to the [=base64url encoding=] of the [=client extension processing=]
         output for [=authenticator extensions=].
 </dl>
 
@@ -4156,7 +4156,7 @@ When this operation is invoked, the [=authenticator=] MUST perform the following
 1. [=list/For each=] |descriptor| of |excludeCredentialDescriptorList|:
 
     1.  If [=credential id/looking up=] <code>|descriptor|.{{PublicKeyCredentialDescriptor/id}}</code> in this authenticator
-        returns non-null, and the returned [=list/item=]'s [=RP ID=] and [=type=] match
+        returns non-null, and the returned [=list/item=]'s [=RP ID=] and [=public key credential source/type=] match
         <code>|rpEntity|.{{PublicKeyCredentialRpEntity/id}}</code> and
         <code>|excludeCredentialDescriptorList|.{{PublicKeyCredentialDescriptor/type}}</code> respectively,
         then collect an [=authorization gesture=] confirming [=user


### PR DESCRIPTION
This would merge into w3c/webauthn#1576.

Fixes:

```
FATAL ERROR: Line 2246 isn't indented enough (needs 1 indent) to be valid Markdown:
"   |savedCredentialIds| and |options|.{{CredentialRequestOptions/publicKey}}."
LINE ~2379: No 'dfn' refs found for 'extension ids'.
[=extension IDs=]
LINE ~4158: Multiple possible 'dfn' local refs for 'type'.
Randomly chose one of them; other instances might get a different random choice.
[=type=]
```

Most remaining issues will be fixed by w3c/webauthn#1746.